### PR TITLE
feat: add todo filtering

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,38 +1,46 @@
-name: Release
+name: PR check
 
 on:
   pull_request:
     branches:
       - main
 
-env:
-  CARGO_TERM_COLOR: always
+# Cancel previously running workflows
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Setup Rust (nightly)
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
+        id: rust-toolchain
         with:
-          profile: minimal
-          toolchain: nightly
           components: rustfmt, clippy
-          override: true
 
-      - name: Run linting
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Run formatting
-        run: cargo fmt --all -- --check
+      - name: Cache cargo
+        uses: actions/cache@v3
+        id: cache-cargo
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests
         run: cargo test --locked
 
+      - name: Run linting
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{collections::HashMap, fs};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::env::args().nth(1);
+    let needle = std::env::args().nth(2);
 
     if path.is_none() {
         println!("Usage: todo <path>");
@@ -15,6 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let path = path.unwrap();
     let mut ok_files = 0;
+    let mut filtered_files = 0;
     let mut todos: HashMap<String, Vec<Todo>> = HashMap::new();
     let supported_filetypes = vec!["ts", "js", "tsx", "jsx", "vue", "html"];
 
@@ -35,13 +37,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let file_contents = fs::read_to_string(entry.path())?;
 
         // Skip files without TODOs
-        if contains_todo_type(&file_contents).is_err() {
-            ok_files += 1;
-            continue;
-        }
+        // if !vec!["//", "<!--"].contains(&file_contents) {
+        //     ok_files += 1;
+        //     continue;
+        // }
 
         for line in file_contents.lines().enumerate() {
             if contains_todo_type(line.1).is_ok() {
+                if needle.is_some() && !line.1.contains(needle.as_ref().unwrap()) {
+                    filtered_files += 1;
+                    continue;
+                }
+
                 todos
                     .entry(entry.path().display().to_string())
                     .or_default()
@@ -50,21 +57,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!(
-        "{ok_files} {} {}\n",
-        match ok_files {
-            1 => "file",
-            _ => "files",
-        },
-        "OK".green(),
-    );
+    match (ok_files, filtered_files) {
+        (0, 0) => println!("No TODOs found"),
+        (0, 1) => println!("1 file filtered"),
+        (1, 0) => println!("1 file OK"),
+        (1, 1) => println!("1 file OK / 1 file filtered"),
+        (_, 0) => println!("{} files OK", ok_files),
+        (_, 1) => println!("{} files OK / 1 file filtered", ok_files),
+        (0, _) => println!("{} files filtered", filtered_files),
+        (1, _) => println!("1 file OK / {} files filtered", filtered_files),
+        (_, _) => println!("{} files OK / {} files filtered", ok_files, filtered_files),
+    }
 
-    for file in todos {
-        for todo in file.1 {
+    println!("");
+
+    for (filename, todos) in todos {
+        for todo in todos {
             println!(
                 "{} {}",
                 todo,
-                file.0.replace(&path, "").bold().bright_black(),
+                filename.replace(&path, "").bold().bright_black(),
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,13 +35,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let file_contents = fs::read_to_string(entry.path())?;
 
         // Skip files without TODOs
-        if !contains_todo_type(&file_contents) {
+        if contains_todo_type(&file_contents).is_err() {
             ok_files += 1;
             continue;
         }
 
         for line in file_contents.lines().enumerate() {
-            if contains_todo_type(line.1) {
+            if contains_todo_type(line.1).is_ok() {
                 todos
                     .entry(entry.path().display().to_string())
                     .or_default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,31 @@
 mod models;
 
-use colored::*;
+use colored::Colorize;
 use jwalk::WalkDir;
 use models::{todo::Todo, todo_type::contains_todo_type};
-use std::{collections::HashMap, fs};
+use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::env::args().nth(1);
     let needle = std::env::args().nth(2);
 
+    // Display help if no path is provided
     if path.is_none() {
         println!("Usage: todo <path>");
         return Ok(());
     }
 
-    let path = path.unwrap();
+    let mut files_scanned = 0;
     let mut ok_files = 0;
     let mut filtered_files = 0;
-    let mut todos: HashMap<String, Vec<Todo>> = HashMap::new();
+    let mut todos: Vec<Todo> = vec![];
+
+    let path = path.unwrap();
     let supported_filetypes = vec!["ts", "js", "tsx", "jsx", "vue", "html"];
 
     for entry in WalkDir::new(&path).sort(true) {
         let entry = entry?;
+        files_scanned += 1;
 
         // Skip directories
         if entry.file_type().is_dir() {
@@ -36,12 +40,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Read the file contents
         let file_contents = fs::read_to_string(entry.path())?;
 
-        // Skip files without TODOs
-        // if !vec!["//", "<!--"].contains(&file_contents) {
-        //     ok_files += 1;
-        //     continue;
-        // }
+        // Skip files without comments
+        if !file_contents.contains("//") && !file_contents.contains("<!--") {
+            ok_files += 1;
+            continue;
+        }
 
+        // Check and parse todos
         for line in file_contents.lines().enumerate() {
             if contains_todo_type(line.1).is_ok() {
                 if needle.is_some() && !line.1.contains(needle.as_ref().unwrap()) {
@@ -49,37 +54,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     continue;
                 }
 
-                todos
-                    .entry(entry.path().display().to_string())
-                    .or_default()
-                    .push(line.into());
+                let todo = (line.0, line.1, entry.path().display().to_string());
+
+                todos.push(todo.into());
             }
         }
     }
 
-    match (ok_files, filtered_files) {
-        (0, 0) => println!("No TODOs found"),
-        (0, 1) => println!("1 file filtered"),
-        (1, 0) => println!("1 file OK"),
-        (1, 1) => println!("1 file OK / 1 file filtered"),
-        (_, 0) => println!("{} files OK", ok_files),
-        (_, 1) => println!("{} files OK / 1 file filtered", ok_files),
-        (0, _) => println!("{} files filtered", filtered_files),
-        (1, _) => println!("1 file OK / {} files filtered", filtered_files),
-        (_, _) => println!("{} files OK / {} files filtered", ok_files, filtered_files),
-    }
+    // Print the results
+    todos.iter().for_each(|todo| println!("{todo}"));
 
-    println!("");
-
-    for (filename, todos) in todos {
-        for todo in todos {
-            println!(
-                "{} {}",
-                todo,
-                filename.replace(&path, "").bold().bright_black(),
-            );
-        }
-    }
+    println!(
+        "\n{} {}\n{} {} scanned {} {} OK {} {} filtered",
+        "Todos:".bold(),
+        todos.len().to_string().blue(),
+        "Files:".bold(),
+        files_scanned.to_string().yellow(),
+        "/".bright_black(),
+        ok_files.to_string().green(),
+        "/".bright_black(),
+        filtered_files.to_string().red(),
+    );
 
     Ok(())
 }

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -1,11 +1,6 @@
-use super::todo_type::TodoType;
+use super::todo_type::{contains_todo_type, TodoType};
 use colored::*;
-use nom::{
-    branch,
-    bytes::complete::{tag, take_till1},
-    character::complete,
-    IResult,
-};
+use nom::{bytes::complete::take_till1, character::complete, IResult};
 use std::fmt::Display;
 
 pub struct Todo {
@@ -16,9 +11,7 @@ pub struct Todo {
 
 fn parse_todo(input: &str, line_number: usize) -> IResult<&str, Todo> {
     let (input, column) = complete::multispace0(input)?;
-    let (input, _) = take_till1(char::is_alphabetic)(input)?;
-    let (input, todo_type) =
-        branch::alt((tag("TODO"), tag("FIX"), tag("WARNING"), tag("NOTE")))(input)?;
+    let (input, todo_type) = contains_todo_type(input)?;
     let (input, _) = take_till1(char::is_alphabetic)(input)?;
 
     Ok((

--- a/src/models/todo.rs
+++ b/src/models/todo.rs
@@ -4,12 +4,13 @@ use nom::{bytes::complete::take_till1, character::complete, IResult};
 use std::fmt::Display;
 
 pub struct Todo {
+    file_path: String,
     line_number: (usize, usize),
     text: String,
     todo_type: TodoType,
 }
 
-fn parse_todo(input: &str, line_number: usize) -> IResult<&str, Todo> {
+fn parse_todo(input: &str, line_number: usize, file_path: String) -> IResult<&str, Todo> {
     let (input, column) = complete::multispace0(input)?;
     let (input, todo_type) = contains_todo_type(input)?;
     let (input, _) = take_till1(char::is_alphabetic)(input)?;
@@ -17,16 +18,17 @@ fn parse_todo(input: &str, line_number: usize) -> IResult<&str, Todo> {
     Ok((
         input,
         Todo {
+            file_path,
             line_number: (line_number + 1, column.len() + 1),
-            text: input.replace(" -->", "").to_string(),
+            text: input.replace("-->", "").trim().to_string(),
             todo_type: todo_type.into(),
         },
     ))
 }
 
-impl From<(usize, &str)> for Todo {
-    fn from((line_number, text): (usize, &str)) -> Self {
-        parse_todo(text, line_number).unwrap().1
+impl From<(usize, &str, String)> for Todo {
+    fn from((line_number, text, path): (usize, &str, String)) -> Self {
+        parse_todo(text, line_number, path).unwrap().1
     }
 }
 
@@ -37,7 +39,11 @@ impl Display for Todo {
             "{} {} {}",
             self.todo_type,
             self.text,
-            format!("[{}:{}]", self.line_number.0, self.line_number.1).bright_black()
+            format!(
+                "[{}:{}:{}]",
+                self.file_path, self.line_number.0, self.line_number.1
+            )
+            .bright_black()
         )
     }
 }
@@ -48,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_todo_from() {
-        let todo = Todo::from((0, "  // TODO: This is a todo"));
+        let todo = Todo::from((0, "  // TODO: This is a todo", "test.rs".to_string()));
 
         assert_eq!(todo.line_number, (1, 3));
         assert_eq!(todo.text, "This is a todo");
@@ -57,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_todo_from_with_other_delimiter() {
-        let todo = Todo::from((0, "  // TODO -> This is a todo"));
+        let todo = Todo::from((0, "  // TODO -> This is a todo", "test.rs".to_string()));
 
         assert_eq!(todo.line_number, (1, 3));
         assert_eq!(todo.text, "This is a todo");
@@ -66,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_todo_from_without_spacing() {
-        let todo = Todo::from((0, "//TODO: This is a todo"));
+        let todo = Todo::from((0, "//TODO: This is a todo", "test.rs".to_string()));
 
         assert_eq!(todo.line_number, (1, 1));
         assert_eq!(todo.text, "This is a todo");
@@ -75,7 +81,7 @@ mod tests {
 
     #[test]
     fn todo_from_removes_closing_tag() {
-        let todo = Todo::from((0, "<!-- TODO: This is a todo -->"));
+        let todo = Todo::from((0, "<!-- TODO: This is a todo -->", "test.rs".to_string()));
 
         assert_eq!(todo.line_number, (1, 1));
         assert_eq!(todo.text, "This is a todo");

--- a/src/models/todo_type.rs
+++ b/src/models/todo_type.rs
@@ -1,4 +1,9 @@
 use colored::*;
+use nom::{
+    branch,
+    bytes::complete::{tag, take_till1},
+    IResult,
+};
 use std::fmt::Display;
 
 #[derive(PartialEq, Debug)]
@@ -32,20 +37,11 @@ impl Display for TodoType {
     }
 }
 
-pub fn contains_todo_type(text: &str) -> bool {
-    let valid_todo_types = vec!["TODO", "FIX", "WARNING", "NOTE"];
+pub fn contains_todo_type(input: &str) -> IResult<&str, &str> {
+    let (input, _) = nom::character::complete::multispace0(input)?;
+    let (input, _) = take_till1(char::is_alphabetic)(input)?;
 
-    for todo_type in valid_todo_types {
-        if text.contains(&format!("// {}", todo_type))
-            || text.contains(&format!("<!-- {}", todo_type))
-            || text.contains(&format!("//{}", todo_type))
-            || text.contains(&format!("<!--{}", todo_type))
-        {
-            return true;
-        }
-    }
-
-    false
+    branch::alt((tag("TODO"), tag("FIX"), tag("WARNING"), tag("NOTE")))(input)
 }
 
 #[cfg(test)]
@@ -55,30 +51,30 @@ mod tests {
     #[test]
     fn test_todo_types() {
         // Handles JS/TS comments
-        assert!(contains_todo_type("// TODO: This is a todo"));
-        assert!(contains_todo_type("// FIX: This is a fix"));
-        assert!(contains_todo_type("// WARNING: This is a warning"));
-        assert!(contains_todo_type("// NOTE: This is a note"));
+        assert!(contains_todo_type("// TODO: This is a todo").is_ok());
+        assert!(contains_todo_type("// FIX: This is a fix").is_ok());
+        assert!(contains_todo_type("// WARNING: This is a warning").is_ok());
+        assert!(contains_todo_type("// NOTE: This is a note").is_ok());
 
         // Handles HTML comments
-        assert!(contains_todo_type("<!-- TODO: This is a todo -->"));
-        assert!(contains_todo_type("<!-- FIX: This is a fix -->"));
-        assert!(contains_todo_type("<!-- WARNING: This is a warning -->"));
-        assert!(contains_todo_type("<!-- NOTE: This is a note -->"));
+        assert!(contains_todo_type("<!-- TODO: This is a todo -->").is_ok());
+        assert!(contains_todo_type("<!-- FIX: This is a fix -->").is_ok());
+        assert!(contains_todo_type("<!-- WARNING: This is a warning -->").is_ok());
+        assert!(contains_todo_type("<!-- NOTE: This is a note -->").is_ok());
     }
 
     #[test]
     fn test_todo_types_without_spacing() {
         // Handles JS/TS comments
-        assert!(contains_todo_type("//TODO: This is a todo"));
-        assert!(contains_todo_type("//FIX: This is a fix"));
-        assert!(contains_todo_type("//WARNING: This is a warning"));
-        assert!(contains_todo_type("//NOTE: This is a note"));
+        assert!(contains_todo_type("//TODO: This is a todo").is_ok());
+        assert!(contains_todo_type("//FIX: This is a fix").is_ok());
+        assert!(contains_todo_type("//WARNING: This is a warning").is_ok());
+        assert!(contains_todo_type("//NOTE: This is a note").is_ok());
 
         // Handles HTML comments
-        assert!(contains_todo_type("<!--TODO: This is a todo-->"));
-        assert!(contains_todo_type("<!--FIX: This is a fix-->"));
-        assert!(contains_todo_type("<!--WARNING: This is a warning-->"));
-        assert!(contains_todo_type("<!--NOTE: This is a note-->"));
+        assert!(contains_todo_type("<!--TODO: This is a todo-->").is_ok());
+        assert!(contains_todo_type("<!--FIX: This is a fix-->").is_ok());
+        assert!(contains_todo_type("<!--WARNING: This is a warning-->").is_ok());
+        assert!(contains_todo_type("<!--NOTE: This is a note-->").is_ok());
     }
 }


### PR DESCRIPTION
By passing a second argument, we can now filter the todos.

```bash
$ todos test 1234
TODO  CNX-1234 This should do something else [test/text.js:6:1]

Todos: 1
Files: 8 scanned / 0 OK / 10 filtered
```